### PR TITLE
Adding hrim_sensor_hygrometer_msgs

### DIFF
--- a/sensor/hygrometer/hrim_sensor_hygrometer_msgs/CMakeLists.txt
+++ b/sensor/hygrometer/hrim_sensor_hygrometer_msgs/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(hrim_sensor_hygrometer_msgs)
+
+# Default to C++14
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+set(msg_files
+  "msg/RelativeHumidity.msg"
+  "msg/SpecsHygrometer.msg"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES builtin_interfaces std_msgs
+)
+
+ament_package()

--- a/sensor/hygrometer/hrim_sensor_hygrometer_msgs/msg/RelativeHumidity.msg
+++ b/sensor/hygrometer/hrim_sensor_hygrometer_msgs/msg/RelativeHumidity.msg
@@ -1,0 +1,13 @@
+# Single reading from a relative humidity sensor.
+# Defines the ratio of partial pressure of water vapor to the saturated vapor
+# pressure at a temperature.
+
+std_msgs/Header header  # timestamp of the measurement
+                             # frame_id is the location of the humidity sensor
+
+float64 relative_humidity    # Expression of the relative humidity
+                             # from 0.0 to 1.0.
+                             # 0.0 is no partial pressure of water vapor
+                             # 1.0 represents partial pressure of saturation
+
+float64 variance # 0 is interpreted as variance unknown

--- a/sensor/hygrometer/hrim_sensor_hygrometer_msgs/msg/SpecsHygrometer.msg
+++ b/sensor/hygrometer/hrim_sensor_hygrometer_msgs/msg/SpecsHygrometer.msg
@@ -1,0 +1,29 @@
+# This message define the most important characteristic of the hygrometer
+
+std_msgs/Header header
+
+float32 resolution	# Minimum change the hygrometer detects (%) I.E. 0.01
+
+float32 max_calibrated_rh	# Maximum relative humidity where the detection accuracy is at it's best (rh)
+float32 min_calibrated_rh	# Minimum relative humidity where the detection accuracy is at it's best (rh)
+
+float32 max_calibrated_temp	# Maximum temperature where the detection accuracy is at it's best (°C)
+float32 min_calibrated_temp	# Minimum temperature where the detection accuracy is at it's best (°C)
+
+float32 accuracy_calibrated	# Average error margin while inside the calibrated ranges (+-rh)
+float32 accuracy_other	# Average error margin while outside the calibrated ranges (+-rh)
+
+float32 max_rh 100	# Maximum operating relative humidity, 100 if unspecified (rh)
+float32 min_rh 0	# Minimum operating relative humidity, 0 if unspecified (rh)
+
+float32 max_temp	# Maximum operating temperature (°C)
+float32 min_temp	# Minimum operating temperature (°C)
+
+float32 max_measure_time  # Maximum amount of time needed for a measurement (s)
+float32 min_measure_time  # Minimum amount of time needed for a measurement (s)
+
+uint8 CAPACITIVE=0
+uint8 RESISTIVE=1
+uint8 THERMAL=2
+uint8 GRAVIMETRIC=3
+uint8 device_type # The way the hygrometer detects relative humidity

--- a/sensor/hygrometer/hrim_sensor_hygrometer_msgs/package.xml
+++ b/sensor/hygrometer/hrim_sensor_hygrometer_msgs/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>hrim_sensor_hygrometer_msgs</name>
+  <version>0.1.0</version>
+  <description>
+     hrim_sensor_hygrometer_msgs defines the messages to interact with a relative humidity meter.
+  </description>
+  <maintainer email="alex@erlerobotics.com">Alejandro Hernández Cordero</maintainer>
+  <maintainer email="irati@erlerobotics.com">Irati Zamalloa</maintainer>
+  <maintainer email="ibai@erlerobotics.com">Ibai Apellaniz</maintainer>
+  <license>All rights reserved</license>
+
+  <url></url>
+  <author>alex@erlerobotics.com</author>
+  <author>irati@erlerobotics.com</author>
+  <author>ibai@erlerobotics.com</author>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <exec_depend>message_generation</exec_depend> <!-- provide message generation to downstream packages -->
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
RelativeHumidity.msg file is taken directly from the default [ROS2 sensor_msgs](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/RelativeHumidity.msg).

The operative relative humidity range has default values seeing many researched sensors don't specify it, might be unnecessary.

The accuracy values are set as an average as many researched sensors specify a single value for when inside and outside "ideal" rh and temp ranges but others have multiple (as in +-1% between 10-20ºC, +-2% between 20-30ºC and +-3% over 30ºC).

Values referencing ranges of relative humidity (in specs) possibly don't need to be floating point values, most datasheets show integer values.

A single (handheld) sensor was found while researching that permitted adjusting the measurement time, could be implemented by adding the amount of time to the RelativeHumidity.msg and a way to change that value. Maybe taking the measurements on-demand (receiving that value) instead of continuously? The measurement times tend to be long enough for this (commonly taking multiple seconds to complete).