### PR TITLE
Adding hrim_sensor_force_msgs

### DIFF
--- a/sensor/force/hrim_sensor_force_msgs/CMakeLists.txt
+++ b/sensor/force/hrim_sensor_force_msgs/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(hrim_sensor_force_msgs)
+
+# Default to C++14
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+set(msg_files
+  "msg/ForceAxis.msg"
+  "msg/Force.msg"
+  "msg/SpecsForceAxis.msg"
+  "msg/SpecsForce.msg"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES builtin_interfaces std_msgs
+)
+
+ament_package()

--- a/sensor/force/hrim_sensor_force_msgs/msg/Force.msg
+++ b/sensor/force/hrim_sensor_force_msgs/msg/Force.msg
@@ -1,0 +1,5 @@
+# Single measurement from a force sensor
+
+std_msgs/Header header
+
+hrim_sensor_force_msgs/ForceAxis[<=3] axis_forces # Array containing separate force readings from each measured axis

--- a/sensor/force/hrim_sensor_force_msgs/msg/ForceAxis.msg
+++ b/sensor/force/hrim_sensor_force_msgs/msg/ForceAxis.msg
@@ -1,0 +1,8 @@
+# Single axis measurement from a force sensor
+
+uint8 X=0
+uint8 Y=1
+uint8 Z=2
+uint8 axis # The axis of the measurement
+
+float64 force # Reading of the force measuring in newtons (N)

--- a/sensor/force/hrim_sensor_force_msgs/msg/ForceAxis.msg
+++ b/sensor/force/hrim_sensor_force_msgs/msg/ForceAxis.msg
@@ -1,8 +1,5 @@
 # Single axis measurement from a force sensor
 
-uint8 X=0
-uint8 Y=1
-uint8 Z=2
-uint8 axis # The axis of the measurement
+uint8 axis # The axis of the measurement - Defined in SpecsForceAxis
 
 float64 force # Reading of the force measuring in newtons (N)

--- a/sensor/force/hrim_sensor_force_msgs/msg/SpecsForce.msg
+++ b/sensor/force/hrim_sensor_force_msgs/msg/SpecsForce.msg
@@ -1,0 +1,13 @@
+# Specs for a force sensor
+
+std_msgs/Header header
+
+hrim_sensor_force_msgs/SpecsForceAxis[<=3] axis_specs # Specs related to each of the measured axes
+
+uint16 max_rate # Maximum amount of measurements per second (Hz)
+
+float32 min_ideal_temp	# Minimum temperature where the error margin is at it's lowest (°C)
+float32 max_ideal_temp	# Maximum temperature where the error margin is at it's lowest (°C)
+
+float32 min_operating_temp # Minimum operating temperature (°C)
+float32 max_operating_temp	# Maximum operating temperature (°C)

--- a/sensor/force/hrim_sensor_force_msgs/msg/SpecsForceAxis.msg
+++ b/sensor/force/hrim_sensor_force_msgs/msg/SpecsForceAxis.msg
@@ -1,0 +1,18 @@
+# Specs for a single axis of a force sensor
+
+uint8 X=0
+uint8 Y=1
+uint8 Z=2
+uint8 axis # The axis the specs describe
+
+uint16 max_force # Maximum measurable force (N)
+
+float32 resolution # Minimum detectable difference (N)
+
+bool bidirectional  # If the axis also measures negative values or not (true,false)
+
+uint16 safe_overload # Maximum force the sensor withstands safely on this axis, in reference to the max_force value (%)
+uint16 max_overload  # Maximum force the sensor withstands before total breakdown on this axis, in reference to the max_force value (%)
+
+float32 min_error_margin	# Average error margin while inside the ideal ranges of this axis (±%)
+float32 max_error_margin	# Average error margin while outside the ideal ranges of this axis (±%)

--- a/sensor/force/hrim_sensor_force_msgs/msg/SpecsForceAxis.msg
+++ b/sensor/force/hrim_sensor_force_msgs/msg/SpecsForceAxis.msg
@@ -1,8 +1,8 @@
 # Specs for a single axis of a force sensor
 
-uint8 X=0
-uint8 Y=1
-uint8 Z=2
+uint8 FORCE_AXIS_X=0
+uint8 FORCE_AXIS_Y=1
+uint8 FORCE_AXIS_Z=2
 uint8 axis # The axis the specs describe
 
 uint16 max_force # Maximum measurable force (N)

--- a/sensor/force/hrim_sensor_force_msgs/package.xml
+++ b/sensor/force/hrim_sensor_force_msgs/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>hrim_sensor_force_msgs</name>
+  <version>0.1.0</version>
+  <description>
+     hrim_sensor_force_msgs defines the messages to interact with a
+     force sensor.
+  </description>
+  <maintainer email="alex@erlerobotics.com">Alejandro Hernández Cordero</maintainer>
+  <maintainer email="irati@erlerobotics.com">Irati Zamalloa</maintainer>
+  <maintainer email="ibai@erlerobotics.com">Ibai Apellaniz</maintainer>
+  <license>All rights reserved</license>
+
+  <url></url>
+  <author>alex@erlerobotics.com</author>
+  <author>irati@erlerobotics.com</author>
+  <author>ibai@erlerobotics.com</author>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <exec_depend>message_generation</exec_depend> <!-- provide message generation to downstream packages -->
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Decided on an array of <=3 length for specs and readings as force-sensors have a lot of variety, for example a 2-axis sensor with different max force capabilities and with different error margins for each axis. 

Both specs and reading messages of each axis state themselves which axis they describe/measure.