### PR TITLE
Add State|SpecsCommunication to CMakeLists.txt, fix compilation

### DIFF
--- a/hrim_generic_msgs/CMakeLists.txt
+++ b/hrim_generic_msgs/CMakeLists.txt
@@ -23,6 +23,8 @@ set(msg_files
   "msg/Power.msg"
   "msg/Simulation3D.msg"
   "msg/SimulationURDF.msg"
+  "msg/SpecsCommunication.msg"
+  "msg/StateCommunication.msg"
   "msg/Status.msg"
 )
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/hrim_generic_msgs/msg/SpecsCommunication.msg
+++ b/hrim_generic_msgs/msg/SpecsCommunication.msg
@@ -1,6 +1,6 @@
 std_msgs/Header header
 
-double min_comm_rate          # the minimum frequency at which the component can work (Hz)
-double max_comm_rate          # the maximum frequency at which the component can work (Hz)
+float64 min_comm_rate          # the minimum frequency at which the component can work (Hz)
+float64 max_comm_rate          # the maximum frequency at which the component can work (Hz)
 
-double max_size_msgs          # the maximum amount of megabits that the component will send (Mb)
+float64 max_size_msgs          # the maximum amount of megabits that the component will send (Mb)

--- a/hrim_generic_msgs/msg/StateCommunication.msg
+++ b/hrim_generic_msgs/msg/StateCommunication.msg
@@ -1,4 +1,4 @@
 std_msgs/Header header
 
-double comm_rate             # the frequency at which the component is working (Hz)
-double size_msgs             # the  megabits that the component in sending (Mb)
+float64 comm_rate             # the frequency at which the component is working (Hz)
+float64 size_msgs             # the  megabits that the component in sending (Mb)


### PR DESCRIPTION
The SpecsCommunication.msg and StateCommunication.msg weren't being compiled, guessing because of compilation errors.

Added then files to CMakeLists.txt, fixed compilation issue (ROS 2 double type maps to float64).